### PR TITLE
add KPG's space packet/primary header parser to the list

### DIFF
--- a/_data/crates.yaml
+++ b/_data/crates.yaml
@@ -60,6 +60,11 @@
   github: nsmryan/ccsds_primary_header
   topics: ["protocol"]
 
+- name: ccsds_spacepacket
+  description: A memory-safe implementation of the Primary Header from the CCSDS Space Packet Protocol based on KubOS's implementation.
+  github: KubOS-Preservation-Group/ccsds-spacepacket
+  topics: ["protocol"]
+
 
 # <------------------------- Parsers ------------------------>
 - name: YANP


### PR DESCRIPTION
in all honesty, there probably need to be some changes to the library like adding docs for docs.rs and publishing to  crates.io (see https://github.com/KubOS-Preservation-Group/ccsds-spacepacket/issues/8) so the badges dont show up as a series of errors
![Screenshot_20211012_110610](https://user-images.githubusercontent.com/17362949/136981635-124c8e97-165c-4f36-b4b3-4e44b4c19a81.png)
 